### PR TITLE
feat: use gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ ENV FLASK_APP app.py
 
 EXPOSE 5000
 
-CMD ["flask", "run", "--host=0.0.0.0"]
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "app:app"]

--- a/charts/grace/values.yaml
+++ b/charts/grace/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: shteou/grace
-  tag: 1.0.0
+  tag: 1.1.0
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Click==7.0
 Flask==1.1.1
+gunicorn==20.1.0
 itsdangerous==1.1.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1


### PR DESCRIPTION
Added gunicorn instead of the flask development server
In specific, this allows flask to terminate gracefully on SIGTERM
so we can better test graceful shutdown