### PR TITLE
feat: add multiple gunicorn workers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ ENV FLASK_APP app.py
 
 EXPOSE 5000
 
-CMD ["gunicorn", "--bind", "0.0.0.0:5000", "app:app"]
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "10", "app:app"]

--- a/charts/grace/values.yaml
+++ b/charts/grace/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: shteou/grace
-  tag: 1.1.0
+  tag: 1.1.1
   pullPolicy: Always
 
 imagePullSecrets: []


### PR DESCRIPTION
Flask is synchronous, so time.sleep blocks the entire python
process. Switched gunicorn to run multiple workers to allow more
concurrent requests to be processed